### PR TITLE
chore(repo): remove 'status-page' from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ taiko-mono/
 │   ├── <a href="./packages/protocol">protocol</a>: Taiko protocol and bridge smart contracts.
 │   ├── <a href="./packages/relayer">relayer</a>: Bridge backend relayer in Go.
 │   ├── <a href="./packages/starter-dapp">starter-dapp</a>: Template for Taiko dapps.
-│   └── <a href="./packages/status-page">status-page</a>: Taiko protocol status page.
 ...
 </pre>
 


### PR DESCRIPTION
Remove the description of 'packages/status-page' in the project structure from the README.